### PR TITLE
fix: 小修改，解决tableAction配置tooltip项或popConfirm项时点击事件触发两次的问题。

### DIFF
--- a/src/components/core/dynamic-table/src/components/table-action.vue
+++ b/src/components/core/dynamic-table/src/components/table-action.vue
@@ -1,6 +1,6 @@
 <template>
   <template v-for="(actionItem, index) in getActions" :key="`${index}-${actionItem.label}`">
-    <ActionItemRender v-bind="actionItem">
+    <ActionItemRender :action="actionItem">
       <a-button
         type="link"
         size="small"
@@ -24,7 +24,7 @@
   import { Icon } from '@/components/basic/icon';
   import { isPromise } from '@/utils/is';
 
-  const ActionItemRender: FunctionalComponent<ActionItem> = (action, { slots }) => {
+  const ActionItemRender: FunctionalComponent<{ action: ActionItem }> = ({ action }, { slots }) => {
     const { popConfirm, tooltip } = action;
     const PopconfirmRender = () => {
       if (popConfirm) {


### PR DESCRIPTION
ActionItemRender中返回的组件会一并携带上v-bind中的所有属性，里层外层会有两个onClick监听触发同一个回调，所以修改v-bind为以单一属性actionItem对象，或者直接传递popConfirm和tooltip两个属性