### PR TITLE
feat: 不修改原schema

### DIFF
--- a/src/components/core/schema-form/src/schema-form-item.vue
+++ b/src/components/core/schema-form/src/schema-form-item.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script setup lang="tsx">
-  import { computed, unref, toRefs, isVNode, watch, nextTick } from 'vue';
+  import { computed, unref, toRefs, isVNode, watch, nextTick, ref } from 'vue';
   import { cloneDeep, debounce, isEqual } from 'lodash-es';
   import { Form, Col, Spin, Divider } from 'ant-design-vue';
   import { useItemLabelWidth } from './hooks/useLabelWidth';
@@ -83,7 +83,21 @@
 
   const { t } = useI18n();
 
-  const { schema } = toRefs(props);
+  // const { schema } = toRefs(props);
+  function deepCopy(obj) {
+    if (typeof obj !== 'object' || obj === null) {
+      return obj;
+    }
+
+    let copy = {};
+    for (let key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        copy[key] = deepCopy(obj[key]);
+      }
+    }
+    return copy;
+  }
+  const schema = ref(deepCopy(props.schema));
 
   const itemLabelWidthProp = useItemLabelWidth(schema, formPropsRef);
 


### PR DESCRIPTION
原来 formSchemaItem 在有 request 的情况下会因为要修改 loading 而修改原来的 formSchemaItem ，
这要会导致我定义的componentProps原来是函数，给修改成对象了，
导致使用的时候最新数据得不到最新的 formModel 导致报错 ，
虽然说 将我的 Schemas 写成函数的形式会解决 这个问题，但是我感觉不修改外部的schemas 好一点
希望得到大佬的关注，非常感谢 
![微信图片_20250418190413](https://github.com/user-attachments/assets/c7529dd2-0c0e-4c3f-9653-3514cc6df3ad)
![微信图片_20250418190545](https://github.com/user-attachments/assets/84579999-bf3b-4e05-8f25-979d919a9ec4)
