### PR TITLE
fix: 修复台式电脑下当前电量显示NaN问题

### DIFF
--- a/src/views/dashboard/welcome/index.vue
+++ b/src/views/dashboard/welcome/index.vue
@@ -51,7 +51,7 @@
           ? calcDischargingTime.value
           : '未知',
       电池状态: batteryStatus.value,
-      当前电量: `${battery.level}%`,
+      当前电量: battery.level ? `${battery.level}%` : '未知',
     });
   });
 


### PR DESCRIPTION
笔记本才会显示电池电量，台式时没有